### PR TITLE
fix: code generation to handle required on object

### DIFF
--- a/src/codegens/golang.ts
+++ b/src/codegens/golang.ts
@@ -86,7 +86,7 @@ export default class Golang extends CodeGen {
       const propSchema = s.properties[key];
       let isRequired = false;
       if (s.required) {
-        isRequired = s.required.indexOf(propSchema.title) !== -1;
+        isRequired = s.required.indexOf(key) !== -1;
       }
       return [
         ...typings,

--- a/src/codegens/rust.test.ts
+++ b/src/codegens/rust.test.ts
@@ -135,6 +135,7 @@ describe("codegen: rust", () => {
           fooThing: { $ref: "#/definitions/foo" },
           barThing: { $ref: "#/definitions/bar" },
         },
+        required: ["fooThing"],
         definitions: {
           foo: { title: "foo", type: "string" },
           bar: { title: "bar", type: "string" },
@@ -143,7 +144,7 @@ describe("codegen: rust", () => {
       expect(generator.transpile()).toBe([
         "#[derive(Serialize, Deserialize)]",
         "pub struct Testerooskies {",
-        "    pub(crate) fooThing: Option<Foo>,",
+        "    pub(crate) fooThing: Foo,",
         "    pub(crate) barThing: Option<Bar>,",
         "}",
         "pub type Foo = String;",

--- a/src/codegens/rust.ts
+++ b/src/codegens/rust.ts
@@ -95,7 +95,7 @@ export default class Rust extends CodeGen {
       const propSchema = s.properties[key];
       let isRequired = false;
       if (s.required) {
-        isRequired = s.required.indexOf(propSchema.title) !== -1;
+        isRequired = s.required.indexOf(key) !== -1;
       }
 
       const typeName = this.getSafeTitle(this.refToTitle(propSchema));

--- a/src/codegens/typescript.test.ts
+++ b/src/codegens/typescript.test.ts
@@ -118,6 +118,7 @@ describe("codegen: typescript", () => {
           fooThing: { $ref: "#/definitions/foo" },
           barThing: { $ref: "#/definitions/bar" },
         },
+        required: ["fooThing"],
         definitions: {
           foo: { title: "foo", type: "string" },
           bar: { title: "bar", type: "string" },
@@ -125,7 +126,7 @@ describe("codegen: typescript", () => {
       });
       expect(generator.transpile()).toBe([
         "export interface Testerooskies {",
-        "  fooThing?: Foo;",
+        "  fooThing: Foo;",
         "  barThing?: Bar;",
         "  [k: string]: any;",
         "}",

--- a/src/codegens/typescript.ts
+++ b/src/codegens/typescript.ts
@@ -78,7 +78,7 @@ export default class Typescript extends CodeGen {
       const propSchema = s.properties[key];
       let isRequired = false;
       if (s.required) {
-        isRequired = s.required.indexOf(propSchema.title) !== -1;
+        isRequired = s.required.indexOf(key) !== -1;
       }
       const title = this.getSafeTitle(this.refToTitle(propSchema));
       return [...typings, `  ${key}${isRequired ? "" : "?"}: ${title};`];


### PR DESCRIPTION
This change fixes bug with required properties on
object, where required wasn't being respected.
fixes #36