### PR TITLE
fix(go): add multiline with anchor

### DIFF
--- a/src/codegens/golang.ts
+++ b/src/codegens/golang.ts
@@ -7,7 +7,7 @@ export default class Golang extends CodeGen {
     const n = super.getSafeTitle(title);
 
     // Remove all non-capitalized-alpha characters before the first capitalized alpha character.
-    return n.replace(/[^A-Z]+/, "");
+    return n.replace(/^[^A-Z]+/m, "");
   }
 
   protected generate(s: JSONSchema, ir: TypeIntermediateRepresentation) {


### PR DESCRIPTION
The problem is the names come out wrong because all lowercase letters get removed.

Give the regex a multiline flag, and enforces that the `[^A-Z]+` match happen at the beginning of the line (the name).

I tested it by installing this build as a local filepath dependency in github.com/open-rpc/meta-schema and running `build` there. It generated a Go doc that looked right.

Signed-off-by: meows <b5c6@protonmail.com>